### PR TITLE
ENG-1730: adopt Testnet4 blockstream proxy with Helm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,120 @@
+name: Build and Deploy
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  ARTIFACT_REGISTRY_LOCATION: us-central1
+  ARTIFACT_REGISTRY_REPO: electrs-batch-server
+  GCP_PROJECT_ID: lygos-infra
+  IMAGE_NAME: electrs-batch-server
+  WIF_PROVIDER: projects/785481412233/locations/global/workloadIdentityPools/github-actions/providers/github
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  build-push:
+    name: Build and Push Image
+    if: >-
+      github.ref == 'refs/heads/master' ||
+      startsWith(github.ref, 'refs/tags/v')
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      image_reference: ${{ steps.digest.outputs.image_reference }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: electrs-batch-server-builder@lygos-infra.iam.gserviceaccount.com
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker "${ARTIFACT_REGISTRY_LOCATION}-docker.pkg.dev"
+
+      - name: Build and push image
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          IMAGE_REPOSITORY="${ARTIFACT_REGISTRY_LOCATION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REGISTRY_REPO}/${IMAGE_NAME}"
+          SHA_TAG="$IMAGE_REPOSITORY:$SOURCE_SHA"
+
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            ALIAS_TAG="$IMAGE_REPOSITORY:$GITHUB_REF_NAME"
+          else
+            ALIAS_TAG="$IMAGE_REPOSITORY:testnet4"
+          fi
+
+          docker build --pull --platform linux/amd64 \
+            --tag "$SHA_TAG" \
+            --tag "$ALIAS_TAG" .
+          docker push "$SHA_TAG"
+          docker push "$ALIAS_TAG"
+
+      - name: Resolve image digest
+        id: digest
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          IMAGE_REPOSITORY="${ARTIFACT_REGISTRY_LOCATION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REGISTRY_REPO}/${IMAGE_NAME}"
+          SHA_TAG="$IMAGE_REPOSITORY:$SOURCE_SHA"
+          DIGEST="$(gcloud artifacts docker images describe "$SHA_TAG" --format='value(image_summary.digest)')"
+
+          if [[ ! "$DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "Invalid image digest: $DIGEST" >&2
+            exit 1
+          fi
+
+          echo "image_reference=$IMAGE_REPOSITORY@$DIGEST" >> "$GITHUB_OUTPUT"
+
+  deploy-testnet4:
+    name: Deploy to Testnet4
+    if: github.ref == 'refs/heads/master'
+    needs: build-push
+    permissions:
+      contents: read
+      deployments: write
+      id-token: write
+    uses: LygosLabs/infrastructure/.github/workflows/deploy-service.yml@deploy-v3
+    with:
+      environment: testnet4
+      service: blockstream-proxy
+      image_reference: ${{ needs.build-push.outputs.image_reference }}
+      chart_version: "0.1.0"
+      values_path: deploy/values/testnet4.yaml
+      source_repository: ${{ github.repository }}
+      source_sha: ${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM --platform=linux/amd64 node:14-alpine
+FROM node:14-alpine
 
 WORKDIR /usr/src/electrs-batch-server
 
-COPY package*.json .
+COPY package*.json ./
 
 RUN npm install
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ docker run \
     electrs-batch-server
 ```
 
+### Deployment
+
+Pushes to `master` build an immutable Artifact Registry image and deploy it to
+Testnet4 through the shared Lygos Helm workflow. Version tags matching `v*`
+build the exact tagged commit and publish both commit and version tags; they are
+the release trigger for production deployments.
+
 ### License
 
 [MIT](./LICENSE.md)

--- a/deploy/values/testnet4.yaml
+++ b/deploy/values/testnet4.yaml
@@ -1,0 +1,90 @@
+nameOverride: blockstream-proxy
+fullnameOverride: blockstream-proxy
+
+replicaCount: 2
+
+image:
+  repository: us-central1-docker.pkg.dev/lygos-infra/electrs-batch-server/electrs-batch-server
+  tag: testnet4
+  pullPolicy: Always
+
+serviceAccount:
+  create: true
+  name: blockstream-proxy
+
+deployment:
+  labels:
+    app: blockstream-proxy-deployment
+  selectorLabels:
+    app: blockstream-proxy-deployment
+  container:
+    name: blockstream-proxy
+    ports:
+      - containerPort: 8080
+    env:
+      - name: PORT
+        value: "8080"
+      - name: ELECTRS_URL
+        value: http://electrs.mempool.svc.cluster.local:3000
+      - name: CONCURRENCY
+        value: "10"
+      - name: PROXY_MODE
+        value: "true"
+    resources:
+      requests:
+        memory: 128Mi
+        cpu: 50m
+      limits:
+        memory: 256Mi
+        cpu: 200m
+
+podLabels:
+  app: blockstream-proxy-deployment
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    minDomains: 2
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app: blockstream-proxy-deployment
+
+service:
+  enabled: true
+  name: blockstream-proxy-service
+  selector:
+    app: blockstream-proxy-deployment
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: blockstream-proxy
+
+httpRoute:
+  enabled: true
+  name: blockstream-proxy
+  parentRefs:
+    - name: external
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - testnet4-node.lygos.finance
+  rules:
+    - backendRefs:
+        - name: blockstream-proxy-service
+          port: 8080
+
+backendPolicy:
+  enabled: true
+  name: blockstream-proxy-service
+  spec:
+    default:
+      securityPolicy: lygos-testnet4-edge-security
+
+podDisruptionBudget:
+  enabled: true
+  name: blockstream-proxy
+  minAvailable: 1
+  selector:
+    app: blockstream-proxy-deployment

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ let accessToken = null
 let tokenExpiresAt = 0
 let tokenRequestInProgress = null
 
-async function getAccessToken() {
+async function getAccessToken () {
   if (!BLOCKSTREAM_CLIENT_ID || !BLOCKSTREAM_CLIENT_SECRET) {
     return null
   }
@@ -64,7 +64,7 @@ async function getAccessToken() {
   }
 }
 
-async function performTokenRequest() {
+async function performTokenRequest () {
   try {
     console.log(`[${new Date().toISOString()}] Requesting new Blockstream access token...`)
 
@@ -363,15 +363,15 @@ if (PROXY_MODE === 'true') {
 
   // GET /api/address/:address/txs/chain/:last_seen_txid - Get confirmed transaction history with pagination
   app.get('/api/address/:address/txs/chain/:last_seen_txid', asyncHandler(async (req, res, next) => {
-    const { address, last_seen_txid } = req.params
+    const { address, last_seen_txid: lastSeenTxid } = req.params
     const timestamp = new Date().toISOString()
-    console.log(`[${timestamp}] /api/address/${address}/txs/chain/${last_seen_txid} - Proxy request to Blockstream`)
+    console.log(`[${timestamp}] /api/address/${address}/txs/chain/${lastSeenTxid} - Proxy request to Blockstream`)
 
     try {
-      const response = await electrs.get(`/address/${address}/txs/chain/${last_seen_txid}`)
+      const response = await electrs.get(`/address/${address}/txs/chain/${lastSeenTxid}`)
       res.json(response.data)
     } catch (error) {
-      console.log(`[${timestamp}] /api/address/${address}/txs/chain/${last_seen_txid} - Error: ${error.message}`)
+      console.log(`[${timestamp}] /api/address/${address}/txs/chain/${lastSeenTxid} - Error: ${error.message}`)
       throw error
     }
   }))
@@ -829,7 +829,7 @@ if (PROXY_MODE !== 'true') {
       service: 'electrs-batch-server',
       version: '1.0.4',
       description: 'Electrs middleware server for batch API calls',
-            endpoints: [
+      endpoints: [
         'POST /addresses - Get address information for multiple addresses',
         'POST /addresses/utxo - Get UTXOs for multiple addresses',
         'POST /addresses/transactions - Get transactions for multiple addresses',
@@ -882,5 +882,5 @@ app.listen(PORT, () => {
   console.log(`API Authentication: ${BLOCKSTREAM_CLIENT_ID ? 'ENABLED' : 'DISABLED'}`)
   console.log(`Proxy Mode: ${PROXY_MODE === 'true' ? 'ENABLED' : 'DISABLED'}`)
   console.log(`Time: ${new Date().toISOString()}`)
-  console.log(`=====================================`)
+  console.log('=====================================')
 })


### PR DESCRIPTION
## Summary

- add repository CI, Artifact Registry image publication, digest resolution, and Testnet4 deployment through `deploy-service@deploy-v3`
- add weekly Dependabot updates for pinned GitHub Actions
- reproduce all six centralized Testnet4 resources with `lygos-service` chart `0.1.0`
- preserve the existing proxy code and correct its pre-existing StandardJS violations so CI can enforce the repository test
- keep Testnet4 deployment on `master` pushes while publishing version-tagged images from `v*` tags for the production migration in ENG-1680
- make the legacy Dockerfile portable while keeping release builds pinned to `linux/amd64`

## Validation

- `npm test`
- `actionlint -shellcheck='' .github/workflows/deployment.yml`
- parsed `.github/dependabot.yml` as YAML
- `helm lint ... --strict --values deploy/values/testnet4.yaml` with digest overrides
- local Helm render inspected: six resources with live names/selectors/specs preserved
- local Docker build and `/health` proxy-mode smoke test
- `git diff --check`

The existing dependency audit reports 34 vulnerabilities. Dependency modernization is intentionally outside this ownership migration.

## Coordination

Linear: https://linear.app/lygos/issue/ENG-1730/adopt-testnet4-blockstream-proxy-deployment-into-electrs-batch-server
Production follow-up: https://linear.app/lygos/issue/ENG-1680/adopt-production-blockstream-proxy-deployment-into-electrs-batch
Infrastructure: https://github.com/LygosLabs/infrastructure/pull/107
Retirement: https://github.com/LygosLabs/lygos-deployment/pull/244

This is one of three coordinated PRs. **Do not merge independently.** Merging this PR triggers the Testnet4 build and Helm deployment.

Cutover order:

1. Merge and apply the infrastructure IAM PR.
2. Merge the retirement PR and wait for its non-pruning Testnet4 deployment.
3. Adopt the existing six resources into the `blockstream-proxy` Helm release.
4. Merge this PR.

<!-- tenki:walkthrough:start -->
## Tenki walkthrough

This PR establishes CI/CD infrastructure for automated deployment to GCP Artifact Registry and Kubernetes. It adds GitHub Actions workflows for testing, building, and deploying container images, configures Helm values for Testnet4, and includes code formatting improvements to the Node.js application.

### Changes

| File | Change |
| --- | --- |
| `.github/dependabot.yml` | New file: Configures Dependabot to automatically check for GitHub Actions workflow updates weekly with appropriate labels and commit prefixes. |
| `.github/workflows/deployment.yml` | New file: CI/CD pipeline that runs tests on PRs, builds and pushes Docker images to GCP Artifact Registry on master/tag commits, and triggers Helm-based deployments to Testnet4. |
| `Dockerfile` | Removed platform-specific prefix from base image and fixed COPY destination path convention (added trailing slash for clarity). |
| `README.md` | Added Deployment section explaining the automated workflow: master builds trigger Testnet4 deployments, version tags trigger production releases. |
| `deploy/values/testnet4.yaml` | New file: Helm values for blockstream-proxy service on Testnet4, configuring replicas, resource limits, HTTP routing, and pod disruption budgets. |
| `index.js` | Code formatting: standardized function spacing, renamed camelCase variable in route parameter, and fixed quote consistency in console.log calls. |

### Where to focus

- deployment.yml — GCP authentication and Artifact Registry integration; verify workload identity and service account are correctly configured
- deployment.yml build-push job — image tagging logic for master (testnet4) vs version tags; ensure aliases match expected naming
- testnet4.yaml — Helm configuration correctness, especially HTTPRoute hostnames and backend policy references
- Dockerfile — verify platform constraints are handled by build workflow rather than base image
<!-- tenki:walkthrough:end -->