### PR TITLE
Configure Testnet4 blockstream proxy health checks

### DIFF
--- a/deploy/values/testnet4.yaml
+++ b/deploy/values/testnet4.yaml
@@ -30,6 +30,14 @@ deployment:
         value: "10"
       - name: PROXY_MODE
         value: "true"
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
     resources:
       requests:
         memory: 128Mi
@@ -81,6 +89,17 @@ backendPolicy:
   spec:
     default:
       securityPolicy: lygos-testnet4-edge-security
+
+healthCheckPolicy:
+  enabled: true
+  name: blockstream-proxy-service
+  spec:
+    default:
+      config:
+        type: HTTP
+        httpHealthCheck:
+          port: 8080
+          requestPath: /health
 
 podDisruptionBudget:
   enabled: true


### PR DESCRIPTION
## Summary
- add a Kubernetes readiness probe for the existing `GET /health` endpoint
- add a GKE Gateway `HealthCheckPolicy` targeting `/health` on port 8080
- align pod and NEG health evaluation to avoid the 15-minute NEG readiness fallback

## Validation
- `helm template blockstream-proxy ../infrastructure/charts/lygos-service --namespace lygos --values deploy/values/testnet4.yaml --set-string image.digest=sha256:ad260072124eba1b8a1d609f209ac82961897c5eabd718a13e00dfc3321fa446 --set-string image.tag=`
- `ruby -e 'require "yaml"; YAML.load_file("deploy/values/testnet4.yaml")'`\n- `git diff --check`\n- `npm test` could not complete because the sandbox denied StandardJS cache creation at `/Users/alex/.standard-v14-cache`

<!-- tenki:walkthrough:start -->
## Tenki walkthrough

Added health check probes to the blockstream-proxy Kubernetes deployment configuration for testnet4. The changes enable two layers of health checking: container-level readiness probes for pod lifecycle management, and a dedicated health check policy for load balancing and traffic routing decisions. This improves reliability by ensuring traffic is only routed to healthy instances.

### Changes

| File | Change |
| --- | --- |
| `deploy/values/testnet4.yaml` | Added readinessProbe configuration to deployment container and introduced new healthCheckPolicy section with HTTP health check settings targeting /health endpoint on port 8080 |

### Where to focus

- Verify readinessProbe settings match application startup time and health endpoint behavior
- Confirm healthCheckPolicy is compatible with the existing gateway/load balancer stack (appears to use Kubernetes Gateway API)
- Ensure /health endpoint is implemented in the blockstream-proxy application and responds correctly to these probe configurations
<!-- tenki:walkthrough:end -->